### PR TITLE
fix: containers restart after failure

### DIFF
--- a/docker-compose/docker-compose.cadvisor.yml
+++ b/docker-compose/docker-compose.cadvisor.yml
@@ -15,5 +15,6 @@ services:
       - /var/run:/var/run:rw # Mount /var/run for read-write access
       - /sys:/sys:ro # Mount /sys as read-only to access system information
       - /var/lib/docker/:/var/lib/docker:ro # Mount Docker's lib directory as read-only
+    restart: unless-stopped
     networks:
       - radem_network # Network for inter-service communication


### PR DESCRIPTION
This pull request includes a small change to the `docker-compose/docker-compose.cadvisor.yml` file. The change adds a restart policy to the `services` section to ensure the service restarts unless stopped manually.